### PR TITLE
Choices list for Reference Collection was always empty

### DIFF
--- a/src/play/modules/morphia/MorphiaPlugin.java
+++ b/src/play/modules/morphia/MorphiaPlugin.java
@@ -623,7 +623,7 @@ public class MorphiaPlugin extends PlayPlugin {
                         @SuppressWarnings("unchecked")
                         public List<Object> list() {
                             return (List<Object>) ds().createQuery(
-                                    field.getType()).asList();
+                                    fieldType).asList();
                         }
                     };
                 }


### PR DESCRIPTION
fix bug : retrieve the correct field type to get the choices list on a reference collection field
