### PR TITLE
Initial support for posting events when entities change

### DIFF
--- a/samples-and-tests/unit-tests/app/play.plugins
+++ b/samples-and-tests/unit-tests/app/play.plugins
@@ -1,0 +1,1 @@
+1000:plugins.EventTestPlugin

--- a/samples-and-tests/unit-tests/app/plugins/EventTestPlugin.java
+++ b/samples-and-tests/unit-tests/app/plugins/EventTestPlugin.java
@@ -1,0 +1,17 @@
+package plugins;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import play.Logger;
+import play.PlayPlugin;
+
+public class EventTestPlugin extends PlayPlugin {
+
+    public static Map<String, Object> events = new HashMap<String, Object>();
+
+    @Override
+    public void onEvent(String message, Object context) {
+        events.put(message, context);
+    }
+}

--- a/samples-and-tests/unit-tests/test/PluginEventTest.java
+++ b/samples-and-tests/unit-tests/test/PluginEventTest.java
@@ -1,0 +1,55 @@
+import models.Account;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import play.test.UnitTest;
+import plugins.EventTestPlugin;
+
+
+public class PluginEventTest extends UnitTest {
+
+    @Before
+    public void setup() {
+        Account.deleteAll();
+        EventTestPlugin.events.clear();
+    }
+
+    @Test
+    public void testCreationEventIsEmitted() throws Exception {
+        Account account = new Account("foo", "bar");
+        account = account.save();
+
+        assertEquals(EventTestPlugin.events.size(), 1);
+        assertTrue(EventTestPlugin.events.containsKey("MorphiaSupport.objectPersisted"));
+        assertTrue(EventTestPlugin.events.containsValue(account));
+    }
+
+    @Test
+    public void testUpdateEventIsEmitted() throws Exception {
+        Account account = new Account("foo", "bar");
+        account = account.save();
+        EventTestPlugin.events.clear();
+
+        account.login = "upadte";
+        account = account.save();
+
+        assertEquals(EventTestPlugin.events.size(), 1);
+        assertTrue(EventTestPlugin.events.containsKey("MorphiaSupport.objectUpdated"));
+        assertTrue(EventTestPlugin.events.containsValue(account));
+    }
+
+    @Test
+    public void testDeleteEventIsEmitted() throws Exception {
+        Account account = new Account("foo", "bar");
+        account = account.save();
+        EventTestPlugin.events.clear();
+
+        account = account.delete();
+
+        assertEquals(EventTestPlugin.events.size(), 1);
+        assertTrue(EventTestPlugin.events.containsKey("MorphiaSupport.objectDeleted"));
+        assertTrue(EventTestPlugin.events.containsValue(account));
+    }
+
+}


### PR DESCRIPTION
This patch resembles the behaviour from the JPA package, that events get emitted, when an entity is updated, created or deleted.

The following events are posted
- MorphiaSupport.objectPersisted (create)
- MorphiaSupport.objectUpdated (update)
- MorphiaSupport.objectDeleted (delete)

The main cause for this patch is to use the elasticsearch module for automatic indexing of mongodb entities (there is not yet a good elasticsearch river for this).
