### PR TITLE
Supports custom keys to find relations by ID

### DIFF
--- a/samples-and-tests/unit-tests/app/models/edit/CustomKeyChild.java
+++ b/samples-and-tests/unit-tests/app/models/edit/CustomKeyChild.java
@@ -1,0 +1,25 @@
+package models.edit;
+
+import com.google.code.morphia.annotations.Entity;
+import com.google.code.morphia.annotations.Id;
+
+import play.modules.morphia.Model;
+
+/**
+ * An entity that has a custom key annotated with @Id.
+ *
+ */
+@Entity
+public class CustomKeyChild extends Model
+{
+    /**
+     * The custom key
+     */
+    @Id
+    public String key;
+
+    /**
+     * The name.
+     */
+    public String name;
+}

--- a/samples-and-tests/unit-tests/app/models/edit/DefaultKeyChild.java
+++ b/samples-and-tests/unit-tests/app/models/edit/DefaultKeyChild.java
@@ -1,0 +1,18 @@
+package models.edit;
+
+import play.modules.morphia.Model;
+
+import com.google.code.morphia.annotations.Entity;
+
+/**
+ * An entity that uses the default key.
+ * 
+ */
+@Entity
+public class DefaultKeyChild extends Model
+{
+    /**
+     * The name.
+     */
+    public String name;
+}

--- a/samples-and-tests/unit-tests/app/models/edit/Parent.java
+++ b/samples-and-tests/unit-tests/app/models/edit/Parent.java
@@ -1,0 +1,42 @@
+package models.edit;
+
+import java.util.List;
+
+import play.modules.morphia.Model;
+
+import com.google.code.morphia.annotations.Entity;
+import com.google.code.morphia.annotations.Reference;
+
+/**
+ * An entity that acts as parent and keeps references to single and multiple
+ * children.
+ * 
+ */
+@Entity
+public class Parent extends Model
+{
+    /**
+     * The reference to the child that has custom key defined.
+     */
+    @Reference
+    public CustomKeyChild customKeyChild;
+
+    /**
+     * The reference to the child that has default key defined.
+     */
+    @Reference
+    public DefaultKeyChild defaultKeyChild;
+
+    /**
+     * The reference to the children that have custom keys defined.
+     */
+    @Reference
+    public List<CustomKeyChild> customKeyChildren;
+
+    /**
+     * The reference to the children that have default keys defined.
+     */
+    @Reference
+    public List<DefaultKeyChild> defaultKeyChildren;
+
+}

--- a/samples-and-tests/unit-tests/test/ModelEditingTest.java
+++ b/samples-and-tests/unit-tests/test/ModelEditingTest.java
@@ -1,0 +1,109 @@
+import java.util.HashMap;
+
+import models.edit.CustomKeyChild;
+import models.edit.DefaultKeyChild;
+import models.edit.Parent;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import play.test.UnitTest;
+
+/**
+ * The model editing test on references.
+ *
+ */
+public class ModelEditingTest extends UnitTest
+{
+    /**
+     * Clear the models.
+     */
+    @Before
+    public void setup()
+    {
+        Parent.deleteAll();
+        CustomKeyChild.deleteAll();
+        DefaultKeyChild.deleteAll();
+    }
+
+    /**
+     * Test single relation with custom key.
+     */
+    @Test
+    public void testSingleRelationWithCustomKey()
+    {
+        CustomKeyChild child1 = new CustomKeyChild();
+        child1.key = "child1";
+        child1.name = "Child One";
+        child1.save();
+
+        HashMap<String, String[]> params = new HashMap<String, String[]>();
+        params.put("parent.customKeyChild.key", new String[] { "child1" });
+        Parent parent = new Parent();
+        parent = parent.edit("parent", params);
+        
+        Assert.assertNotNull(parent.customKeyChild);
+        Assert.assertEquals(child1.name, parent.customKeyChild.name);
+    }
+    
+    /**
+     * Test single relation with default key.
+     */
+    @Test
+    public void testSingleRelationWithDefaultKey()
+    {
+        DefaultKeyChild child1 = new DefaultKeyChild();
+        child1.name = "Child One";
+        child1.save();
+
+        HashMap<String, String[]> params = new HashMap<String, String[]>();
+        params.put("parent.defaultKeyChild._id", new String[] { child1._key().toString() });
+        Parent parent = new Parent();
+        parent = parent.edit("parent", params);
+        
+        Assert.assertNotNull(parent.defaultKeyChild);
+        Assert.assertEquals(child1.name, parent.defaultKeyChild.name);
+    }
+    
+    /**
+     * Test multiple relation with custom key.
+     */
+    @Test
+    public void testMultipleRelationWithCustomKey()
+    {
+        CustomKeyChild child1 = new CustomKeyChild();
+        child1.key = "child1";
+        child1.name = "Child One";
+        child1.save();
+
+        HashMap<String, String[]> params = new HashMap<String, String[]>();
+        params.put("parent.customKeyChildren.key", new String[] { "child1" });
+        Parent parent = new Parent();
+        parent = parent.edit("parent", params);
+        
+        Assert.assertNotNull(parent.customKeyChildren);
+        Assert.assertEquals(1, parent.customKeyChildren.size());
+        Assert.assertEquals(child1.name, parent.customKeyChildren.get(0).name);
+    }
+    
+    /**
+     * Test multiple relation with default key.
+     */
+    @Test
+    public void testMultipleRelationWithDefaultKey()
+    {
+        DefaultKeyChild child1 = new DefaultKeyChild();
+        child1.name = "Child One";
+        child1.save();
+
+        HashMap<String, String[]> params = new HashMap<String, String[]>();
+        params.put("parent.defaultKeyChildren._id", new String[] { child1._key().toString() });
+        Parent parent = new Parent();
+        parent = parent.edit("parent", params);
+        
+        Assert.assertNotNull(parent.defaultKeyChildren);
+        Assert.assertEquals(1, parent.defaultKeyChildren.size());
+        Assert.assertEquals(child1.name, parent.defaultKeyChildren.get(0).name);
+    }
+}

--- a/src/play/modules/morphia/Model.java
+++ b/src/play/modules/morphia/Model.java
@@ -28,6 +28,7 @@ import play.Play;
 import play.data.binding.BeanWrapper;
 import play.data.validation.Validation;
 import play.exceptions.UnexpectedException;
+import play.modules.morphia.MorphiaPlugin.MorphiaModelLoader;
 import play.modules.morphia.utils.IdGenerator;
 import play.mvc.Scope.Params;
 
@@ -130,10 +131,10 @@ public class Model implements Serializable, play.db.Model {
                Class<Model> c = (Class<Model>) Play.classloader
                      .loadClass(relation);
                if (Model.class.isAssignableFrom(c)) {
+                  MorphiaPlugin.MorphiaModelLoader f = (MorphiaModelLoader) MorphiaPlugin.MorphiaModelLoader
+                        .getFactory(c);
                   String keyName = null;
                   if (!isEmbedded) {
-                     play.db.Model.Factory f = MorphiaPlugin.MorphiaModelLoader
-                           .getFactory((Class<? extends Model>) o.getClass());
                      keyName = f.keyName();
                   }
                   if (multiple
@@ -159,10 +160,8 @@ public class Model implements Serializable, play.db.Model {
                               if (_id.equals("")) {
                                  continue;
                               }
-                              Query<Model> q = ds().createQuery(c).filter(
-                                    keyName, processId_(_id));
                               try {
-                                 l.add(q.get());
+                                 l.add(f.findById(_id));
                               } catch (Exception e) {
                                  Validation.addError(
                                        name + "." + field.getName(),
@@ -183,10 +182,8 @@ public class Model implements Serializable, play.db.Model {
                      String[] ids = params.get(name1);
                      if (ids != null && ids.length > 0 && !ids[0].equals("")) {
                         params.remove(name1);
-                        Query<Model> q = ds().createQuery(c).filter(keyName,
-                              processId_(ids[0]));
                         try {
-                           Object to = q.get();
+                           Object to = f.findById(ids[0]);
                            bw.set(field.getName(), o, to);
                         } catch (Exception e) {
                            Validation.addError(name0, "validation.notFound",


### PR DESCRIPTION
Find relations by ID now supports custom keys (annotated with @id).

Sorry, but I somehow messed up with my first attempt to create a pull request. Here's the new one containing the tests as well.

Michael
