### PR TITLE
multitenant support

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project name="morphia module" default="javadoc" basedir=".">
-
+    <property file="build.properties" />
     <path id="project.classpath">
         <pathelement path="${play.path}/framework/classes"/>
         <fileset dir="${play.path}/framework">

--- a/samples-and-tests/unit-tests/test/MultitenantTest.java
+++ b/samples-and-tests/unit-tests/test/MultitenantTest.java
@@ -1,0 +1,59 @@
+import java.util.Set;
+
+import models.Account;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.After;
+import org.junit.Test;
+
+import play.Logger;
+import play.Play;
+import play.modules.morphia.MorphiaPlugin;
+import play.modules.morphia.ThreadLocalTenantContext;
+import play.test.UnitTest;
+
+public class MultitenantTest extends UnitTest {
+
+    @Before
+    public void setup() {
+        MorphiaPlugin.setMultitenantMode(true);
+        MorphiaPlugin.setTenantContext(new ThreadLocalTenantContext());
+        ThreadLocalTenantContext.setTenant("tenant1");
+        Account.deleteAll();
+        ThreadLocalTenantContext.setTenant("tenant2");
+        Account.deleteAll();
+    }
+    @After
+    public void tearDown() {
+        MorphiaPlugin.setMultitenantMode(false);
+    }
+
+    @Test
+    public void testTwoTenants() {
+        ThreadLocalTenantContext.setTenant("tenant1");
+        Assert.assertEquals(0, Account.count());
+        Account acc = new Account("loginxyz", "a@a.a");
+        acc.save();
+        Assert.assertEquals(1, Account.count());
+        
+        ThreadLocalTenantContext.setTenant("tenant2");
+        Assert.assertEquals(0, Account.count());
+        Account acc2 = new Account("loginxyz", "a@a.a");
+        acc2.save();
+        Assert.assertEquals(1, Account.count());
+        Account acc3 = new Account("loginxyz2", "a@a.a2");
+        acc3.save();
+        Assert.assertEquals(2, Account.count());
+
+        ThreadLocalTenantContext.setTenant("tenant1");
+        Assert.assertEquals(1, Account.count());
+
+        ThreadLocalTenantContext.setTenant("tenant2");
+        Assert.assertEquals(2, Account.count());
+        
+        
+    }
+
+
+}

--- a/src/play/modules/morphia/TenantContext.java
+++ b/src/play/modules/morphia/TenantContext.java
@@ -1,0 +1,28 @@
+package play.modules.morphia;
+
+/**
+ * Provides play-morphia information about the currently operated tenant.
+ * Implementations of this class could be something that holds the current
+ * tenant in Request.args, or it could hold the current tenant in ThreadLocal.
+ * 
+ * @author antti.poyhonen@gmail.com
+ * 
+ */
+public interface TenantContext {
+
+    /**
+     * @return current tenant id, or null if tenant isn't known currently
+     */
+    public String getTenant();
+
+    /**
+     * Modifies the current collectionName to be tenant specific. Not called for
+     * classes specified in configuration option "morphia.nonTenantClasses"
+     * 
+     * @param collectionName
+     *            original collection name based on morphia annotation mappings
+     * @return collectionName used for the current tenant (for example:
+     *         getTenant()+'_'+collectionName).
+     */
+    public String modifyCollectionName(String collectionName);
+}

--- a/src/play/modules/morphia/TenantDatastore.java
+++ b/src/play/modules/morphia/TenantDatastore.java
@@ -1,0 +1,77 @@
+package play.modules.morphia;
+
+import java.util.HashSet;
+
+import play.Play;
+
+import com.google.code.morphia.DatastoreImpl;
+import com.google.code.morphia.Morphia;
+import com.mongodb.DBCollection;
+import com.mongodb.Mongo;
+
+/**
+ * Provides multitenancy support to play-morphia by overriding Morphia's default
+ * DatastoreImpl. Multitenancy support in current implementation means that
+ * collection names can be changed dynamically based on the current tenant. This
+ * implementation relies on the assumption that Morphia will always use the
+ * getCollection-method before operating on a collection.
+ * 
+ * @author antti.poyhonen@gmail.com
+ * 
+ */
+public class TenantDatastore extends DatastoreImpl {
+
+    private HashSet<String> excludedClasses;
+    private TenantContext tenantContext;
+    private boolean multitenantMode;
+
+    public TenantDatastore(Morphia morphia, Mongo mongo, String dbName, String username, char[] password) {
+        super(morphia, mongo, dbName, username, password);
+        this.multitenantMode = "true".equals(Play.configuration.getProperty("morphia.multitenantMode", "false"));
+        this.tenantContext = null;
+        this.excludedClasses = new HashSet<String>();
+        for (String className : Play.configuration.getProperty("morphia.nonTenantClasses", "").split(",")) {
+            if (className.trim().length() > 0) {
+                excludedClasses.add(className.trim());
+            }
+        }
+    }
+
+    public TenantContext getTenantContext() {
+        return tenantContext;
+    }
+
+    public void setTenantContext(TenantContext tenantContext) {
+        this.tenantContext = tenantContext;
+    }
+
+    public boolean isMultitenantMode() {
+        return multitenantMode;
+    }
+
+    public void setMultitenantMode(boolean multitenantMode) {
+        this.multitenantMode = multitenantMode;
+    }
+
+    @Override
+    public DBCollection getCollection(Class clazz) {
+        if (!isMultitenantMode() || excludedClasses.contains(clazz.getName())) {
+            return super.getCollection(clazz);
+        }
+
+        String tenant = null;
+        if (tenantContext != null) {
+            tenant = tenantContext.getTenant();
+        }
+
+        if (tenant == null) {
+            String msg = "Current tenant not set while operating on tenant specific class: " + clazz.getName();
+            throw new IllegalStateException(msg);
+        } else {
+            DBCollection coll = super.getCollection(clazz);
+            String collName = tenantContext.modifyCollectionName(coll.getName());
+            return getDB().getCollection(collName);
+        }
+    }
+
+}

--- a/src/play/modules/morphia/ThreadLocalTenantContext.java
+++ b/src/play/modules/morphia/ThreadLocalTenantContext.java
@@ -1,0 +1,39 @@
+package play.modules.morphia;
+
+/**
+ * TenantContext implemenation that uses ThreadLocal. Remember to clearTenant
+ * after request has been handled (or is suspended). Play reuses threads for
+ * multiple request and the same will also be reused if a request is suspended.
+ * 
+ * @author antti.poyhonen@gmail.com
+ * 
+ */
+public class ThreadLocalTenantContext implements TenantContext {
+    private static ThreadLocal<String> userLocal = new ThreadLocal<String>();
+
+    public static void setTenant(String tenant) {
+        userLocal.set(tenant);
+    }
+
+    public static void clearTenant() {
+        userLocal.set(null);
+    }
+
+    public static boolean hasTenant() {
+        return userLocal.get() != null;
+    }
+
+    @Override
+    public String getTenant() {
+        return userLocal.get();
+    }
+
+    @Override
+    public String modifyCollectionName(String collectionName) {
+        if (getTenant() == null) {
+            return collectionName;
+        }
+        return getTenant() + '_' + collectionName;
+    }
+
+}


### PR DESCRIPTION
I saw that you were considering implementing multitenant support to play-morphia. I would really like to see this happen, so here's one take on implementing multitenant support to play-morphia.

This implementation allows modifying the collection name for each tenant. I couldn't find clear documentation on how to modify Morphia's collection names dynamically, but overriding DatastoreImpl.getCollection seemed to work against the current test suite and also in my own testing.
