### PR TITLE
Added test for referenced models through YML files

### DIFF
--- a/samples-and-tests/unit-tests/app/models/Child.java
+++ b/samples-and-tests/unit-tests/app/models/Child.java
@@ -1,0 +1,12 @@
+package models;
+
+import play.modules.morphia.Model;
+import com.google.code.morphia.annotations.Entity;
+
+@SuppressWarnings("serial")
+@Entity
+public class Child extends Model{
+	
+	public String childName;
+
+}

--- a/samples-and-tests/unit-tests/app/models/Parent.java
+++ b/samples-and-tests/unit-tests/app/models/Parent.java
@@ -1,0 +1,16 @@
+package models;
+
+import play.modules.morphia.Model;
+import com.google.code.morphia.annotations.Entity;
+import com.google.code.morphia.annotations.Reference;
+
+@SuppressWarnings("serial")
+@Entity
+public class Parent extends Model{
+	
+	public String parentName;
+	
+	@Reference
+	public Child child;
+
+}

--- a/samples-and-tests/unit-tests/conf/initial-data.yml
+++ b/samples-and-tests/unit-tests/conf/initial-data.yml
@@ -1,0 +1,6 @@
+ Child(child1):
+   childName: child
+ Parent(parent1):
+   parentName: parent
+   childName: child1
+ 

--- a/samples-and-tests/unit-tests/test/ReferenceYMLTest.java
+++ b/samples-and-tests/unit-tests/test/ReferenceYMLTest.java
@@ -1,0 +1,33 @@
+
+
+import models.Parent;
+import models.Child;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import play.Logger;
+import play.test.UnitTest;
+import play.test.MorphiaFixtures;
+
+/**
+ * Test the correct loading of references through yml files
+ */
+public class ReferenceYMLTest extends UnitTest {
+
+    @Before
+    public void setup() {
+    	Logger.info("Deleting data...");
+    	MorphiaFixtures.delete(Child.class, Parent.class);
+    	Logger.info("Inserting data...");
+    	MorphiaFixtures.loadModels("initial-data.yml");
+    }
+
+    @Test
+    public void testSimpleReference() {
+       Parent parent = Parent.find("byParentName","parent").first();
+       Assert.assertNotNull("Parent not found!", parent);
+       Assert.assertNotNull("Child is null, reference didn't load correctly",parent.child);
+    }
+}


### PR DESCRIPTION
Hi,

I forked the project to add the unit test for the issue with the Reference classes in the Yaml files. Strangely I had to add the dependency to the morphia module to make it work (in the dependencies there was only the one for CRUD).

I just added two new models: Parent and Child, one having a reference to the other
I also added a initial-data.yml file and a new test ReferenceYMLTest really simple, that loads the initial data and then check that the dependency is not null.

More tests could be added, for Embedded and multiple references, but I think for now this is enough to see the problem.

Hope it helps :)
Jose Salguero
