### PR TITLE
Adds tests for Blob in Abstract parent not available to Concrete Child Enitity

### DIFF
--- a/samples-and-tests/unit-tests/app/models/AbstractParent.java
+++ b/samples-and-tests/unit-tests/app/models/AbstractParent.java
@@ -1,0 +1,8 @@
+package models;
+
+import play.modules.morphia.Blob;
+import play.modules.morphia.Model;
+
+public class AbstractParent extends Model {
+	public Blob image;
+}

--- a/samples-and-tests/unit-tests/app/models/ConcreteChild.java
+++ b/samples-and-tests/unit-tests/app/models/ConcreteChild.java
@@ -1,0 +1,8 @@
+package models;
+
+import com.google.code.morphia.annotations.Entity;
+
+@Entity
+public class ConcreteChild extends AbstractParent {
+
+}

--- a/samples-and-tests/unit-tests/test/EnhanceAbstractParentTest.java
+++ b/samples-and-tests/unit-tests/test/EnhanceAbstractParentTest.java
@@ -1,0 +1,17 @@
+import models.ConcreteChild;
+
+import org.junit.Test;
+
+import play.test.UnitTest;
+
+/**
+ * Blob from parent should be available to child
+ *
+ */
+public class EnhanceAbstractParentTest extends UnitTest {
+
+	@Test
+	public void testCreateConcreteChild() {
+		ConcreteChild child = new ConcreteChild();
+	}
+}


### PR DESCRIPTION
Careful, this test case breaks at startup, during class enhancement it appears.
