### PR TITLE
Fix for Issue 92: Syntax error in morphiaFixture.tag

### DIFF
--- a/app/views/tags/morphiaFixture.tag
+++ b/app/views/tags/morphiaFixture.tag
@@ -20,4 +20,4 @@
             throw new play.exceptions.TagInternalException('Cannot apply ' + _arg + ' fixture because of ' + e.getClass().getName() + ', ' + e.getMessage())
         }
     }
-%}
+}%


### PR DESCRIPTION
Changed %} to }%
