### PR TITLE
Close MongoDB connection in onApplicationStop() to release resources.

### DIFF
--- a/src/play/modules/morphia/MorphiaPlugin.java
+++ b/src/play/modules/morphia/MorphiaPlugin.java
@@ -705,6 +705,12 @@ public final class MorphiaPlugin extends PlayPlugin {
         appStarted_ = true;
     }
 
+    @Override
+    public void onApplicationStop() {
+        mongo_.close();
+        appStarted_ = false;
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     private void registerEventHandlers_() {
         if (!Boolean.parseBoolean(Play.configuration.getProperty("morphia.autoRegisterEventHandler", "true"))) return;


### PR DESCRIPTION
In our Play 1.2.5 based application, we observed that in DEV mode, some code changes would trigger Play's detectChanges() to restart the application. This is done by Play by calling stop() followed by start(). For modules, this results in calls to onApplicationStop() followed by onApplicationStart().

If onApplicationStop() doesn't close Mongo connection, the following onApplicationStart() causes an InterruptedException deep inside Java MongoDB driver, in a Semaphore#tryAcquire() call. Eventually, the entire application becomes unstable and crashes.
